### PR TITLE
30 | Remove 'none' option from tags dropdown in form

### DIFF
--- a/resources/views/admin/posts/posts/form.blade.php
+++ b/resources/views/admin/posts/posts/form.blade.php
@@ -164,7 +164,6 @@
                             {{ $tag->name }}
                         </option>
                     @empty
-                        <option value="">{{ __('label.none')}}</option>
                     @endforelse
                 </select>
                 @error('tags')


### PR DESCRIPTION
**Deployment:**

* git pull

**Rollback:**

* git checkout x

**Tickets:**

* https://trello.com/c/Ca3PgtAZ/30-30-bug-error-while-saving-tag-none

**Updates:**

* ...